### PR TITLE
adding prepublish command so the library will build before publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ node_js:
   - "10"
   - "8"
 
-branches:
-  only:
-    - master
-
 install:
   - travis_retry npm install
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev": "tsdx watch",
     "prebuild": "npm run test",
     "build": "tsdx build",
+    "prepublish": "npm run build",
     "test": "tsdx test --env=jsdom",
     "lint": "prettier --write \"src/**/*\" \"stories/**/*\" \"test/**/*\" \"README.md\" \"docs/**/*\" && tsdx lint --fix \"src/**/*\" \"test/**/*\"",
     "coveralls": "tsdx test --coverage && cat ./coverage/lcov.info | coveralls",


### PR DESCRIPTION
closes #43 

* adds a prepublish command which will build the project so the dist/ folder cannot ever be missing. 