### PR TITLE
build: added '@hospitalrun/component' on dependencies - package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@fortawesome/fontawesome-svg-core": "~1.2.25",
     "@fortawesome/free-solid-svg-icons": "~5.11.2",
     "@fortawesome/react-fontawesome": "~0.1.4",
+    "@hospitalrun/components": "~0.4.3",
     "chart.js": "^2.8.0",
     "formik": "^1.5.8",
     "moment": "^2.24.0",


### PR DESCRIPTION
**Changes proposed in this pull request:**
Added "@hospitalrun/components" at dependencies on package.json file

Reason: 
1 - The storybook don't run without this dependency.
2 - When I tried to install it using "npm install @hospitalrun/components" as mentioned, there is a confliction with the name of the project.

Obs: Another way to solve this would be change the project name to something else, install the dependency and replace the project name to what it was.

This is my first PR, if something is wrong, sorry about it.
