### PR TITLE
fix(navbar): fixed navbar navigating you to a 404 page

### DIFF
--- a/stories/navbar.stories.tsx
+++ b/stories/navbar.stories.tsx
@@ -70,7 +70,6 @@ storiesOf('Navbar', module)
                 onClick: () => {
                   Toast('success', 'Sublink1 clicked!!', 'Success')
                 },
-                href: '/somepath',
               },
               {
                 label: 'Sublink2',


### PR DESCRIPTION
Clicking on sublink1 would display a success toast but then navigate you to 'somepath' which 404's

**Changes proposed in this pull request:**
- removed the href from sublink1
