### PR TITLE
fix(richtext.test): window.matchMedia is not a function

### DIFF
--- a/__mocks__/matchMediaMock.js
+++ b/__mocks__/matchMediaMock.js
@@ -1,0 +1,10 @@
+window.matchMedia = jest.fn().mockImplementation((query) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: jest.fn(), // deprecated
+  removeListener: jest.fn(), // deprecated
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  dispatchEvent: jest.fn(),
+}))

--- a/package.json
+++ b/package.json
@@ -123,12 +123,13 @@
     "moment": "~2.24.0",
     "react-spinners": "~0.6.1",
     "react-toastify": "~5.4.1",
-    "tinymce": "~5.0.16"
+    "tinymce": "~5.1.2"
   },
   "jest": {
     "setupFiles": [
       "jest-canvas-mock",
-      "<rootDir>test-setup.ts"
+      "<rootDir>test-setup.ts",
+      "<rootDir>/__mocks__/matchMediaMock.js"
     ],
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -15,7 +15,7 @@ interface Props {
   value?: string
 
   /** Handles the onChange event for the Select. */
-  onChange?: (event: React.FormEvent<HTMLSelectElement>) => void
+  onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void
   /** The children to render */
   children?: React.ReactNode
 }


### PR DESCRIPTION
Fixes #113.

**Changes proposed in this pull request:**
- Change Select component onChange prop type to `React.ChangeEvent` from `React.FormEvent` which gives type error `Type '(event: FormEvent<Form<"input"> & HTMLInputElement>) => void' is not assignable to type '(event: FormEvent<ReplaceProps<"input", BsPrefixProps<"input"> & FormControlProps>>) => void'.`
- Add mock for window.matchMedia which throws `not a function` error in *richtext.test.tsx*