### PR TITLE
feat(dashboard): adds dashboard icon

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -11,6 +11,7 @@ const iconMap = {
   'appointment-add': 'calendar-plus',
   'appointment-remove': 'calendar-minus',
   calendar: 'calendar-alt',
+  dashboard: 'columns',
   image: 'camera',
   incident: 'file-alt',
   lab: 'microscope',

--- a/src/components/Icon/interfaces.ts
+++ b/src/components/Icon/interfaces.ts
@@ -5,6 +5,7 @@ export type IconType =
   | 'appointment-add'
   | 'appointment-remove'
   | 'calendar'
+  | 'dashboard'
   | 'image'
   | 'incident'
   | 'lab'

--- a/stories/icons.stories.tsx
+++ b/stories/icons.stories.tsx
@@ -18,7 +18,6 @@ storiesOf('Icons', module)
       <span>Admin: </span>
       <Icon icon="admin" />
       <br />
-
       <span>Apointment: </span>
       <Icon icon="appointment" />
       <br />
@@ -28,11 +27,12 @@ storiesOf('Icons', module)
       <span>Remove Apointment: </span>
       <Icon icon="appointment-remove" />
       <br />
-
       <span>Calendar: </span>
       <Icon icon="calendar" />
       <br />
-
+      <span>Dashboard: </span>
+      <Icon icon="dashboard" />
+      <br />
       <span>Image: </span>
       <Icon icon="image" />
       <br />

--- a/test/icon.test.tsx
+++ b/test/icon.test.tsx
@@ -35,6 +35,13 @@ describe('Icon', () => {
     expect(fontAwesomeIcon.props().icon).toBe('calendar-alt')
   })
 
+  it('Dashboard Icon renders itself without crashing', () => {
+    const dashboardIconWrapper = shallow(<Icon icon="dashboard" />)
+    const fontAwesomeIcon = dashboardIconWrapper.find(FontAwesomeIcon)
+    expect(fontAwesomeIcon).toHaveLength(1)
+    expect(fontAwesomeIcon.props().icon).toBe('columns')
+  })
+
   it('Image Icon renders itself without crashing', () => {
     const imageIconWrapper = shallow(<Icon icon="image" />)
     const fontAwesomeIcon = imageIconWrapper.find(FontAwesomeIcon)


### PR DESCRIPTION
Add dashboard icon to Icon component and create successful test. 

re #135

Fixes #135

Decided on the column icon for it being efficient, simple and most unambiguous out of the other fontawesome choices. 