### PR TITLE
feat(components): add Label isRequired property and other options

### DIFF
--- a/docs/Label.md
+++ b/docs/Label.md
@@ -7,6 +7,6 @@ Labels are used to display text
 | property         | propType          | required | default | description              |
 | ---------------- | ----------------- | -------- | ------- | ------------------------ |
 | text             | `string`          | yes      | -       | Text to display in label |
-| title            | `string | undefined`               | -        | -       | Title of the label       |
-| htmlFor          | `string | ''`     | -        | -       | Ties labels to input     |
-| isRequired       | `boolean`         | -        | false   | Defines whether input is required |
+| title            | `string`          | no       | -       | Title of the label       |
+| htmlFor          | `string`          | -        | -       | Ties labels to input     |
+| isRequired       | `boolean`         | no       | false   | Defines whether input is required |

--- a/docs/Label.md
+++ b/docs/Label.md
@@ -7,6 +7,6 @@ Labels are used to display text
 | property         | propType          | required | default | description              |
 | ---------------- | ----------------- | -------- | ------- | ------------------------ |
 | text             | `string`          | yes      | -       | Text to display in label |
-| title            | ''                | -        | -       | Title of the label       |
+| title            | `string | undefined`               | -        | -       | Title of the label       |
 | htmlFor          | `string | ''`     | -        | -       | Ties labels to input     |
 | isRequired       | `boolean`         | -        | false   | Defines whether input is required |

--- a/docs/Label.md
+++ b/docs/Label.md
@@ -7,7 +7,6 @@ Labels are used to display text
 | property         | propType          | required | default | description              |
 | ---------------- | ----------------- | -------- | ------- | ------------------------ |
 | text             | `string`          | yes      | -       | Text to display in label |
-| title            | `string | ''`     | -        | -       | Title of the label       |
+| title            | `string`          | -        | -       | Title of the label       |
 | htmlFor          | `string | ''`     | -        | -       | Ties labels to input     |
-| disableTitle     | `boolean`         | -        | false   | Disables title           |
 | isRequired       | `boolean`         | -        | false   | Defines whether input is required |

--- a/docs/Label.md
+++ b/docs/Label.md
@@ -1,10 +1,13 @@
 # `Label` (component)
 
-Labels are used to display textnpm
+Labels are used to display text
 
 ## Props
 
-| property | propType      | required | default | description              |
-| -------- | ------------- | -------- | ------- | ------------------------ |
-| htmlFor  | `string | ''` | -        |         | Ties labels to input     |
-| text     | `string`      | yes      |         | Text to display in label |
+| property         | propType          | required | default | description              |
+| ---------------- | ----------------- | -------- | ------- | ------------------------ |
+| text             | `string`          | yes      | -       | Text to display in label |
+| title            | `string | ''`     | -        | -       | Title of the label       |
+| htmlFor          | `string | ''`     | -        | -       | Ties labels to input     |
+| disableTitle     | `boolean`         | -        | false   | Disables title           |
+| isRequired       | `boolean`         | -        | false   | Defines whether input is required |

--- a/docs/Label.md
+++ b/docs/Label.md
@@ -7,6 +7,6 @@ Labels are used to display text
 | property         | propType          | required | default | description              |
 | ---------------- | ----------------- | -------- | ------- | ------------------------ |
 | text             | `string`          | yes      | -       | Text to display in label |
-| title            | `string`          | -        | -       | Title of the label       |
+| title            | ''                | -        | -       | Title of the label       |
 | htmlFor          | `string | ''`     | -        | -       | Ties labels to input     |
 | isRequired       | `boolean`         | -        | false   | Defines whether input is required |

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -15,13 +15,14 @@ interface Props {
   isRequired?: boolean | false
 }
 /**
- *  svg instead of asterisk to avoid asterisk being read by screenreaders
+ *  Svg instead of asterisk to avoid asterisk being read by screenreaders
  *  hidden text to be read explaing the input is required incase the title attribute
  *  is not supported by the screen reader
  */
 const asterisk = React.createElement('i', { style: { color: 'red' }, id: 'required-asterisk' }, [
   <FontAwesomeIcon
     icon="asterisk"
+    key="asterisk"
     style={{ height: '7px', verticalAlign: 'top', marginLeft: '2px' }}
   />,
 ])

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -6,7 +6,7 @@ interface Props {
   /** Text to display in label */
   text: string
   /** Title of the label. */
-  title?: string // Use on required input labels to override default required title
+  title?: '' // Use on required input labels to override default required title
   /** Give option to disable  */
   htmlFor?: string | ''
   /** Defines whether input is required. */

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -7,7 +7,7 @@ interface Props {
   text: string
   /** Title of the label. */
   title?: string // Use on required input labels to override default required title
-  /** Give option to disable  */
+  /** Ties label to input  */
   htmlFor?: string
   /** Defines whether input is required. */
   isRequired?: boolean

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -17,7 +17,7 @@ interface Props {
  *  hidden text to be read explaing the input is required incase the title attribute
  *  is not supported by the screen reader
  */
-const asterisk = React.createElement('i', { style: { color: 'red' }, id: 'required-asterisk' }, [
+const asterisk = React.createElement('i', { style: { color: 'red' } }, [
   <FontAwesomeIcon
     icon="asterisk"
     key="asterisk"
@@ -29,7 +29,6 @@ const asterisk = React.createElement('i', { style: { color: 'red' }, id: 'requir
  */
 const Label = (props: Props) => {
   const { text, htmlFor, isRequired, title } = props
-
   /** Form label for required inputs */
   if (isRequired) {
     return (

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -6,7 +6,7 @@ interface Props {
   /** Text to display in label */
   text: string
   /** Title of the label. */
-  title?: '' // Use on required input labels to override default required title
+  title?: string // Use on required input labels to override default required title
   /** Give option to disable  */
   htmlFor?: string | ''
   /** Defines whether input is required. */
@@ -47,5 +47,7 @@ const Label = (props: Props) => {
     </FormLabel>
   )
 }
-
+Label.defaultProps = {
+  title: '',
+}
 export { Label }

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,19 +1,56 @@
 import React from 'react'
 import FormLabel from 'react-bootstrap/FormLabel'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 interface Props {
   /** Text to display in label */
   text: string
-  /** Ties labels to input */
+  /** Title of the label. */
+  title?: string | '' // Use on required input labels to override default required title
+  /** Give option to disable  */
   htmlFor?: string | ''
+  /** Disables title */
+  disableTitle?: boolean | false
+  /** Defines whether input is required. */
+  isRequired?: boolean | false
 }
-
 /**
- * Labels are used to display textnpm
+ *  svg instead of asterisk to avoid asterisk being read by screenreaders
+ *  hidden text to be read explaing the input is required incase the title attribute
+ *  is not supported by the screen reader
+ */
+const asterisk = React.createElement('i', { style: { color: 'red' }, id: 'required-asterisk' }, [
+  <FontAwesomeIcon
+    icon="asterisk"
+    style={{ height: '7px', verticalAlign: 'top', marginLeft: '2px' }}
+  />,
+])
+/**
+ * Labels are used to display text
  */
 const Label = (props: Props) => {
-  const { htmlFor, text } = props
-  return <FormLabel htmlFor={htmlFor}>{text}</FormLabel>
+  const { text, htmlFor, isRequired, disableTitle } = props
+  let { title } = props
+  if (disableTitle) {
+    title = ' '
+  }
+  /** Form label for required inputs */
+  if (isRequired) {
+    return (
+      <div>
+        <FormLabel htmlFor={htmlFor} title={title || 'This is a required input'}>
+          {text}
+          {asterisk}
+        </FormLabel>
+      </div>
+    )
+  }
+  /** Default form label  */
+  return (
+    <FormLabel htmlFor={htmlFor} title={title}>
+      {text}
+    </FormLabel>
+  )
 }
 
 export { Label }

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -6,13 +6,11 @@ interface Props {
   /** Text to display in label */
   text: string
   /** Title of the label. */
-  title?: string | '' // Use on required input labels to override default required title
+  title?: string // Use on required input labels to override default required title
   /** Give option to disable  */
   htmlFor?: string | ''
-  /** Disables title */
-  disableTitle?: boolean | false
   /** Defines whether input is required. */
-  isRequired?: boolean | false
+  isRequired?: boolean
 }
 /**
  *  Svg instead of asterisk to avoid asterisk being read by screenreaders
@@ -30,11 +28,8 @@ const asterisk = React.createElement('i', { style: { color: 'red' }, id: 'requir
  * Labels are used to display text
  */
 const Label = (props: Props) => {
-  const { text, htmlFor, isRequired, disableTitle } = props
-  let { title } = props
-  if (disableTitle) {
-    title = ' '
-  }
+  const { text, htmlFor, isRequired, title } = props
+
   /** Form label for required inputs */
   if (isRequired) {
     return (

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -8,7 +8,7 @@ interface Props {
   /** Title of the label. */
   title?: string // Use on required input labels to override default required title
   /** Give option to disable  */
-  htmlFor?: string | ''
+  htmlFor?: string
   /** Defines whether input is required. */
   isRequired?: boolean
 }
@@ -48,6 +48,7 @@ const Label = (props: Props) => {
   )
 }
 Label.defaultProps = {
-  title: '',
+  title: undefined,
+  htmlFor: undefined,
 }
 export { Label }

--- a/stories/label.stories.tsx
+++ b/stories/label.stories.tsx
@@ -36,7 +36,6 @@ storiesOf('Label', module)
         title="Custom required input title"
         text="Required input label with custom title"
       />
-      <Label isRequired disableTitle text="Required input label without title" />
       <br />
       <Label text="This label is tied to the input below" htmlFor="inputOne" />
       <TextInput id="inputOne" placeholder="This input is tied to the label above" />

--- a/stories/label.stories.tsx
+++ b/stories/label.stories.tsx
@@ -11,15 +11,33 @@ storiesOf('Label', module)
     },
   })
   .addDecorator((storyFn) => (
-    <div style={{ textAlign: 'center', display: 'flex', flexDirection: 'column', padding: '8px' }}>
+    <div
+      style={{
+        textAlign: 'left',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '8px',
+        marginLeft: '30px',
+      }}
+    >
       {storyFn()}
     </div>
   ))
   .add('Label', () => (
     <>
-      <Label text="This is a label" />
-      <Label text="This is also a label" />
+      <Label text="These are labels!" />
+      <Label text="Username" />
+      <Label text="Password" />
       <Label text="You can type whatever you want in a label!" />
+      <Label text="Label with title" title="Custom title message" />
+      <Label isRequired text="Required input label" />
+      <Label
+        isRequired
+        title="Custom required input title"
+        text="Required input label with custom title"
+      />
+      <Label isRequired disableTitle text="Required input label without title" />
+      <br />
       <Label text="This label is tied to the input below" htmlFor="inputOne" />
       <TextInput id="inputOne" placeholder="This input is tied to the label above" />
     </>

--- a/stories/label.stories.tsx
+++ b/stories/label.stories.tsx
@@ -36,7 +36,6 @@ storiesOf('Label', module)
         title="Custom required input title"
         text="Required input label with custom title"
       />
-      <br />
       <Label text="This label is tied to the input below" htmlFor="inputOne" />
       <TextInput id="inputOne" placeholder="This input is tied to the label above" />
     </>

--- a/test/label.test.tsx
+++ b/test/label.test.tsx
@@ -32,12 +32,15 @@ describe('Label', () => {
 
   it('Required Input Label succesfully renders custom title', () => {
     const labelWrapper = shallow(<Label text="test" isRequired title="test is required" />)
-    expect(labelWrapper.props().title).toEqual('test is required')
+    const bootstrapLabel = labelWrapper.find(FormLabel)
+
+    expect(bootstrapLabel.props().title).toEqual('test is required')
   })
 
   it('Required Input Label disableTitle property successfully removes the title', () => {
     const labelWrapper = shallow(<Label text="test" isRequired disableTitle />)
-    expect(labelWrapper.props().title).toEqual(' ')
+    const bootstrapLabel = labelWrapper.find(FormLabel)
+    expect(bootstrapLabel.props().title).toEqual(' ')
   })
 
   it('Label can add htmlFor prop', () => {

--- a/test/label.test.tsx
+++ b/test/label.test.tsx
@@ -15,6 +15,31 @@ describe('Label', () => {
     expect(bootstrapLabel.text()).toEqual('test')
   })
 
+  it('Required Input Label succesfully renders default required title and asterisk', () => {
+    const labelWrapper = shallow(<Label text="test" isRequired />)
+    const bootstrapLabel = labelWrapper.find(FormLabel)
+
+    /** Ensure asterisk mounted */
+    let asteriskMounted = false
+    bootstrapLabel.props().children.forEach((e: any) => {
+      if (e.props && e.props.id === 'required-asterisk') {
+        asteriskMounted = true
+      }
+    })
+    expect(asteriskMounted).toEqual(true)
+    expect(bootstrapLabel.props().title).toEqual('This is a required input')
+  })
+
+  it('Required Input Label succesfully renders custom title', () => {
+    const labelWrapper = shallow(<Label text="test" isRequired title="test is required" />)
+    expect(labelWrapper.props().title).toEqual('test is required')
+  })
+
+  it('Required Input Label disableTitle property successfully removes the title', () => {
+    const labelWrapper = shallow(<Label text="test" isRequired disableTitle />)
+    expect(labelWrapper.props().title).toEqual(' ')
+  })
+
   it('Label can add htmlFor prop', () => {
     const labelWrapper = shallow(<Label htmlFor="testHtmlFor" text="test" />)
     const bootstrapLabel = labelWrapper.find(FormLabel)

--- a/test/label.test.tsx
+++ b/test/label.test.tsx
@@ -1,51 +1,45 @@
 import * as React from 'react'
 import { shallow } from 'enzyme'
 import { FormLabel } from 'react-bootstrap'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Label } from '../src'
 
 describe('Label', () => {
   it('Label renders itself without crashing', () => {
     const labelWrapper = shallow(<Label text="test" />)
+
     expect(labelWrapper.find(FormLabel)).toHaveLength(1)
   })
 
-  it('Label can render text', () => {
+  it('Label renders text', () => {
     const labelWrapper = shallow(<Label text="test" />)
     const bootstrapLabel = labelWrapper.find(FormLabel)
+
     expect(bootstrapLabel.text()).toEqual('test')
   })
 
   it('Required Input Label succesfully renders default required title and asterisk', () => {
     const labelWrapper = shallow(<Label text="test" isRequired />)
     const bootstrapLabel = labelWrapper.find(FormLabel)
+    const asterisk = bootstrapLabel.find(FontAwesomeIcon)
 
-    /** Ensure asterisk mounted */
-    let asteriskMounted = false
-    bootstrapLabel.props().children.forEach((e: any) => {
-      if (e.props && e.props.id === 'required-asterisk') {
-        asteriskMounted = true
-      }
-    })
-    expect(asteriskMounted).toEqual(true)
+    expect(asterisk).toHaveLength(1)
+    expect(asterisk.prop('icon')).toEqual('asterisk')
     expect(bootstrapLabel.props().title).toEqual('This is a required input')
   })
 
   it('Required Input Label succesfully renders custom title', () => {
-    const labelWrapper = shallow(<Label text="test" isRequired title="test is required" />)
+    const expectedTitleText = 'test is required'
+    const labelWrapper = shallow(<Label text="test" isRequired title={expectedTitleText} />)
     const bootstrapLabel = labelWrapper.find(FormLabel)
 
-    expect(bootstrapLabel.props().title).toEqual('test is required')
+    expect(bootstrapLabel.props().title).toEqual(expectedTitleText)
   })
 
-  it('Required Input Label disableTitle property successfully removes the title', () => {
-    const labelWrapper = shallow(<Label text="test" isRequired disableTitle />)
-    const bootstrapLabel = labelWrapper.find(FormLabel)
-    expect(bootstrapLabel.props().title).toEqual(' ')
-  })
-
-  it('Label can add htmlFor prop', () => {
+  it('Label adds htmlFor prop', () => {
     const labelWrapper = shallow(<Label htmlFor="testHtmlFor" text="test" />)
     const bootstrapLabel = labelWrapper.find(FormLabel)
+
     expect(bootstrapLabel.props().htmlFor).toEqual('testHtmlFor')
   })
 })


### PR DESCRIPTION
Added isRequired property with red svg star that avoids being read as an asterisk by screenreaders,
added a default title for the required input labels that can be modified or disabled using
disableTitle or title property.
I would love some constructive criticism and I think some refactoring might be necessary. 
re #137

I was having issues on my windows environment installing various projects so I am now working on linux pardon any mistakes with my contributions, pull requests, typescript etc as I'm still learning. I'm going to look into fixing these test outcomes as my last request went everything smoothly.

 Please message me if anyone feels I am not properly contributing and should search for an easier project to work on I will not get offended! 😄 