### PR TITLE
fix(typings): adds @types/node package set to version 12 of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/chart.js": "~2.9.7",
     "@types/enzyme": "~3.10.3",
     "@types/jest": "~24.0.25",
+    "@types/node": "~12.12.23",
     "@types/react": "~16.9.17",
     "@types/react-dom": "~16.9.1",
     "@types/sinon": "~7.5.0",


### PR DESCRIPTION
adds missing @types/node package so builds work again

fix #189

Fixes #189 

**Changes proposed in this pull request:**
- adds @types/nodes set to version 12 (version 13 fails to build)

**Newly added dependencies with [Bundlephobia](https://bundlephobia.com/) links:**
- https://bundlephobia.com/result?p=@types/node
