### PR TITLE
fix(toaster): fixes import location so users don't have to import toastify css

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { fas } from '@fortawesome/free-solid-svg-icons'
 
+import 'react-toastify/dist/ReactToastify.min.css'
+
 library.add(fas)
 export * from './components/Toaster'
 export * from './components/Spinner'

--- a/stories/toaster.stories.tsx
+++ b/stories/toaster.stories.tsx
@@ -5,7 +5,6 @@ import { storiesOf } from '@storybook/react'
 import Button from 'react-bootstrap/Button'
 import { Toast, Toaster } from '../src'
 import 'bootstrap/dist/css/bootstrap.min.css'
-import 'react-toastify/dist/ReactToastify.min.css'
 
 storiesOf('Toaster', module)
   .addParameters({


### PR DESCRIPTION
Fixes #[replace brackets with the issue number that your pull request addresses].

**Changes proposed in this pull request:**
- changes css to be imported in the `index.tsx` file so that it does not need to imported in the stories. This makes sure that a user of the library does not have to install react-toastify in order to import the css file.
