### PR TITLE
fix(textinput): add password, search, tel, url input types

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -8,13 +8,13 @@ interface Props {
   /** Determines whether the TextField should be rendered as invalid or not. By default, it is false. */
   isInvalid?: boolean
   /** The name of the text field */
-  name?: string | ''
+  name?: string
   /** The number of rows to render */
   rows?: number
   /** Determines whether to render a small or large TextField. By default, it is undefined. */
   size?: 'small' | 'large'
   /** The value of the text field */
-  value?: string | ''
+  value?: string
 
   /** Handles the onChange event for the TextField */
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -7,15 +7,15 @@ interface Props {
   /** Defines the size of the input. Defaults to 'lg' */
   size?: 'sm' | 'lg'
   /** The value of the input */
-  value?: string | ''
+  value?: string
   /** Handles the onChange event for the input */
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   /** The name of the input */
-  name?: string | ''
+  name?: string
   /** The id value of the input */
-  id?: string | ''
+  id?: string
   /** The placeholder inside of the text input */
-  placeholder?: string | ''
+  placeholder?: string
   /** Defines whether the input should be disabled or not. Defaults to false. */
   disabled?: boolean
   /** Defines whether the input should display as invalid. Defaults to false. */

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -3,7 +3,7 @@ import Form from 'react-bootstrap/Form'
 
 interface Props {
   /** Defines the type of the input. Defaults to 'text' if not specified. */
-  type?: 'text' | 'number' | 'email'
+  type?: 'text' | 'number' | 'email' | 'password' | 'search' | 'tel' | 'url'
   /** Defines the size of the input. Defaults to 'lg' */
   size?: 'sm' | 'lg'
   /** The value of the input */

--- a/stories/textinput.stories.tsx
+++ b/stories/textinput.stories.tsx
@@ -43,6 +43,38 @@ storiesOf('TextInput', module)
       />
     </div>
   ))
+  .add('Default password input', () => (
+    <div>
+      <TextInput type="password" name="text-input" id="text-input" size="lg" value="12345678" />
+    </div>
+  ))
+  .add('Default search input', () => (
+    <div>
+      <TextInput
+        type="search"
+        name="text-input"
+        id="text-input"
+        size="lg"
+        value="testsearchstring"
+      />
+    </div>
+  ))
+  .add('Default tel input', () => (
+    <div>
+      <TextInput type="tel" name="text-input" id="text-input" size="lg" value="123-456-7890" />
+    </div>
+  ))
+  .add('Default url input', () => (
+    <div>
+      <TextInput
+        type="url"
+        name="text-input"
+        id="text-input"
+        size="lg"
+        value="https://www.google.com"
+      />
+    </div>
+  ))
   .add('Disabled text input', () => (
     <div>
       <TextInput


### PR DESCRIPTION
Fixes #226

**Changes proposed in this pull request:**
- Add `password`, `search`, `tel`, `url` input types to `TextInput`

Tested on a phone emulator and `tel`, `number` both cause a numeric keyboard to appear.