### PR TITLE
feat(icons): add Edit icon with pencil

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -13,6 +13,7 @@ const iconMap = {
   calendar: 'calendar-alt',
   dashboard: 'columns',
   'down-arrow': 'chevron-down',
+  edit: 'edit',
   image: 'camera',
   incident: 'file-alt',
   lab: 'microscope',

--- a/src/components/Icon/interfaces.ts
+++ b/src/components/Icon/interfaces.ts
@@ -7,6 +7,7 @@ export type IconType =
   | 'calendar'
   | 'dashboard'
   | 'down-arrow'
+  | 'edit'
   | 'image'
   | 'incident'
   | 'lab'

--- a/stories/icons.stories.tsx
+++ b/stories/icons.stories.tsx
@@ -33,6 +33,9 @@ storiesOf('Icons', module)
       <span>Dashboard: </span>
       <Icon icon="dashboard" />
       <br />
+      <span>Edit: </span>
+      <Icon icon="edit" />
+      <br />
       <span>Image: </span>
       <Icon icon="image" />
       <br />

--- a/test/icon.test.tsx
+++ b/test/icon.test.tsx
@@ -53,6 +53,13 @@ describe('Icon', () => {
     expect(fontAwesomeIcon.props().icon).toBe('columns')
   })
 
+  it('Edit Icon renders itself without crashing', () => {
+    const dashboardIconWrapper = shallow(<Icon icon="edit" />)
+    const fontAwesomeIcon = dashboardIconWrapper.find(FontAwesomeIcon)
+    expect(fontAwesomeIcon).toHaveLength(1)
+    expect(fontAwesomeIcon.props().icon).toBe('edit')
+  })
+
   it('Image Icon renders itself without crashing', () => {
     const imageIconWrapper = shallow(<Icon icon="image" />)
     const fontAwesomeIcon = imageIconWrapper.find(FontAwesomeIcon)


### PR DESCRIPTION
Related to https://github.com/HospitalRun/hospitalrun-frontend/issues/1765

**Changes proposed in this pull request:**
- Add "edit" icon showing a pencil writing on paper which can be used on "Edit" button for Edit Patient and other Edit functionality.
- Icon used: https://fontawesome.com/icons/edit?style=solid