### PR TITLE
feat(modal): styling with props

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, CSSProperties } from 'react'
 import BootstrapModal from 'react-bootstrap/Modal'
 
 import { Button, Props as ButtonProps } from '../Button'
@@ -40,6 +40,14 @@ interface Props {
    * Optional success button properties.
    * */
   successButton?: ButtonProps
+  /**
+   * Custom class-based styling.
+   * */
+  className?: string
+  /**
+   * Custom Inline styling.
+   * */
+  style?: CSSProperties
 }
 
 /**
@@ -58,10 +66,14 @@ const Modal = (props: Props) => {
     closeButton,
     middleButton,
     successButton,
+    className,
+    style,
   } = props
 
   return (
     <BootstrapModal
+      dialogClassName={className}
+      style={style}
       autoFocus
       centered={verticallyCentered}
       keyboard


### PR DESCRIPTION
Modals can now be styled with `className` and `style` props. The `style` prop takes type: `CSSProperties` for inline styling capabilities, and `className` takes type: `string`.

Fixes #442 

**Changes proposed in this pull request:**
- Added style & className props to Modal.tsx

