### PR TITLE
fix(modal): improve modal components

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -49,6 +49,40 @@ interface Props {
    * Styilng through inline CSSProperties
    */
   style?: CSSProperties
+  /**
+   * Include a backdrop component. Specify 'static' for a backdrop that doesn't trigger an "onHide" when clicked. Default = true
+   */
+  backdrop?: true | false | 'static'
+  /**
+   * Callback fired before the Modal transitions in
+   * @param node
+   */
+  onEnter?(node: HTMLElement): any
+  /**
+   * Callback fired after the Modal finishes transitioning in
+   * @param node
+   */
+  onEntered?(node: HTMLElement): any
+  /**
+   * Callback fired as the Modal begins to transition in
+   * @param node
+   */
+  onEntering?(node: HTMLElement): any
+  /**
+   * Callback fired right before the Modal transitions out
+   * @param node
+   */
+  onExit?(node: HTMLElement): any
+  /**
+   * Callback fired after the Modal finishes transitioning out
+   * @param node
+   */
+  onExited?(node: HTMLElement): any
+  /**
+   * Callback fired as the Modal begins to transition out
+   * @param node
+   */
+  onExiting?(node: HTMLElement): any
 }
 
 /**
@@ -69,18 +103,32 @@ const Modal = (props: Props) => {
     successButton,
     className,
     style,
+    backdrop,
+    onEnter,
+    onEntered,
+    onEntering,
+    onExit,
+    onExited,
+    onExiting,
   } = props
 
   return (
     <BootstrapModal
       dialogClassName={className}
+      show={show}
       style={style}
       autoFocus
       centered={verticallyCentered}
       keyboard
       restoreFocus
-      show={show}
       onHide={() => toggle()}
+      backdrop={backdrop || true}
+      onEnter={onEnter}
+      onEntered={onEntered}
+      onEntering={onEntering}
+      onExit={onExit}
+      onExited={onExited}
+      onExiting={onExiting}
     >
       {(showHeaderCloseButton === false ? title : true) && (
         <BootstrapModal.Header closeButton={showHeaderCloseButton !== false}>

--- a/stories/modal.stories.tsx
+++ b/stories/modal.stories.tsx
@@ -16,6 +16,7 @@ storiesOf('Modal', module)
   ))
   .add('Simple modal', () => {
     const [show, setShow] = useState(false)
+    const [log, setLog] = useState('')
     return (
       <div style={{ textAlign: 'center' }}>
         <Button color="info" onClick={() => setShow(!show)}>
@@ -25,6 +26,12 @@ storiesOf('Modal', module)
           show={show}
           toggle={() => setShow(!show)}
           title="This is a modal title!"
+          onEnter={() => setLog(`${log}\n${new Date().toLocaleTimeString()}: onEnter`)}
+          onEntered={() => setLog(`${log}\n${new Date().toLocaleTimeString()}: onEntered`)}
+          onEntering={() => setLog(`${log}\n${new Date().toLocaleTimeString()}: onEntering`)}
+          onExit={() => setLog(`${log}\n${new Date().toLocaleTimeString()}: onExit`)}
+          onExited={() => setLog(`${log}\n${new Date().toLocaleTimeString()}: onExited`)}
+          onExiting={() => setLog(`${log}\n${new Date().toLocaleTimeString()}: onExiting`)}
           body={
             <div>
               <p>And this is a modal body.</p>
@@ -36,11 +43,15 @@ storiesOf('Modal', module)
           closeButton={{
             children: 'Close me',
             onClick: () => {
-              console.log('clicked close')
+              setLog(`${log}\n${new Date().toLocaleTimeString()}: onclicked close`)
               setShow(!show)
             },
           }}
         />
+        <div style={{ textAlign: 'left' }}>
+          <h3>Log:</h3>
+          <pre style={{ border: '1px solid black' }}>{log}</pre>
+        </div>
       </div>
     )
   })


### PR DESCRIPTION
Fixes #586 .

**Changes proposed in this pull request:**

* Include a backdrop component. Specify 'static' for a backdrop that doesn't trigger an "onHide" when clicked. Default = true
   **backdrop?: true | false | 'static'**
  
* Callback fired before the Modal transitions in
  **onEnter?(node: HTMLElement): any**

* Callback fired after the Modal finishes transitioning in
  **onEntered?(node: HTMLElement): any**

* Callback fired as the Modal begins to transition in
   **onEntering?(node: HTMLElement): any**
  
* Callback fired right before the Modal transitions out
  **onExit?(node: HTMLElement): any**
  
* Callback fired after the Modal finishes transitioning out
  **onExited?(node: HTMLElement): any**

* Callback fired as the Modal begins to transition out
  **onExiting?(node: HTMLElement): any**

The modal will not close when you click outside the modal.
```
backdrop={"static"}
```

Full Example
```
<Modal
          show={show}
          toggle={() => setShow(!show)}
          title="This is a modal title!"
backdrop={"static"}
          body={
            <div>
              <p>And this is a modal body.</p>
              <div>
                Simple example with just one button. <br /> The modal body can be any JSX.
              </div>
            </div>
          }
          closeButton={{
            children: 'Close me',
            onClick: () => {
              console.log('clicked close')
              setShow(!show)
            },
          }}
        />
```
