### PR TITLE
feat(select): add the ability to display error messages

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Typeahead } from 'react-bootstrap-typeahead'
 import 'react-bootstrap-typeahead/css/Typeahead.css'
+import Form from 'react-bootstrap/Form'
 
 interface SelectOption<T> {
   label: string
@@ -15,7 +16,9 @@ interface Props<T> {
   placeholder?: string
   multiple?: boolean
   disabled?: boolean
+  isValid?: boolean
   isInvalid?: boolean
+  feedback?: string
 }
 
 function Select<T>(props: Props<T>) {
@@ -27,42 +30,55 @@ function Select<T>(props: Props<T>) {
     placeholder,
     multiple,
     disabled,
+    isValid,
     isInvalid,
+    feedback,
   } = props
 
   return (
-    <Typeahead<SelectOption<T>>
-      id={id}
-      options={options as any}
-      selected={defaultSelected}
-      onChange={(selected: SelectOption<T>[]) => {
-        if (onChange !== undefined) {
-          onChange(selected.map((option) => option.value))
-        }
-      }}
-      placeholder={placeholder}
-      multiple={multiple}
-      disabled={disabled}
-      isInvalid={isInvalid}
-      filterBy={(option: SelectOption<T>, selectProps: any) => {
-        // per https://github.com/HospitalRun/components/issues/517
-        // change component default behavior
-        // multiple - filter-out current selections
-        const isMatch = option.label.toLowerCase().indexOf(selectProps.text.toLowerCase()) !== -1
-        if (selectProps.selected.length && selectProps.multiple) {
-          return selectProps.selected.every(
-            (selected: any) => selected.label !== option.label && isMatch,
-          )
-        }
-        // single (custom)- display all options
-        if (selectProps.selected.length) {
-          return true
-        }
-        // default filter as normal
+    <>
+      <Typeahead<SelectOption<T>>
+        id={id}
+        options={options as any}
+        selected={defaultSelected}
+        onChange={(selected: SelectOption<T>[]) => {
+          if (onChange !== undefined) {
+            onChange(selected.map((option) => option.value))
+          }
+        }}
+        placeholder={placeholder}
+        multiple={multiple}
+        disabled={disabled}
+        isInvalid={isInvalid}
+        filterBy={(option: SelectOption<T>, selectProps: any) => {
+          // per https://github.com/HospitalRun/components/issues/517
+          // change component default behavior
+          // multiple - filter-out current selections
+          const isMatch = option.label.toLowerCase().indexOf(selectProps.text.toLowerCase()) !== -1
+          if (selectProps.selected.length && selectProps.multiple) {
+            return selectProps.selected.every(
+              (selected: any) => selected.label !== option.label && isMatch,
+            )
+          }
+          // single (custom)- display all options
+          if (selectProps.selected.length) {
+            return true
+          }
+          // default filter as normal
 
-        return isMatch
-      }}
-    />
+          return isMatch
+        }}
+      />
+      <div className={isValid ? 'is-valid' : isInvalid ? 'is-invalid' : undefined} />
+      <Form.Control.Feedback
+        className={`text-left ml-3 mt-1 text-small ${
+          isValid ? 'text-success' : isInvalid ? 'text-danger' : undefined
+        }`}
+        type={isValid ? 'valid' : 'invalid'}
+      >
+        {feedback}
+      </Form.Control.Feedback>
+    </>
   )
 }
 

--- a/stories/select.stories.tsx
+++ b/stories/select.stories.tsx
@@ -73,3 +73,29 @@ storiesOf('Select', module)
       />
     </div>
   ))
+  .add('Invalid select with error message', () => (
+    <div>
+      <Select
+        id="select-one"
+        options={options}
+        onChange={(selected) => {
+          Toast('success', 'Selection changed', selected.join(' | '))
+        }}
+        isInvalid
+        feedback="Please select one of the choices"
+      />
+    </div>
+  ))
+  .add('Valid select with custom validation message', () => (
+    <div>
+      <Select
+        id="select-one"
+        options={options}
+        onChange={(selected) => {
+          Toast('success', 'Selection changed', selected.join(' | '))
+        }}
+        isValid
+        feedback="This is a custom valid message"
+      />
+    </div>
+  ))

--- a/test/select.test.tsx
+++ b/test/select.test.tsx
@@ -1,6 +1,7 @@
 import { shallow, mount } from 'enzyme'
 import * as React from 'react'
 import { Typeahead as BootstrapTypeahead } from 'react-bootstrap-typeahead'
+import Form from 'react-bootstrap/Form'
 
 import { Select } from '../src'
 
@@ -32,6 +33,15 @@ describe('Select', () => {
     const selectWrapper = shallow(<Select id="id" options={options} disabled />)
     const bootstratSelect = selectWrapper.find(BootstrapTypeahead)
     expect(bootstratSelect.props().disabled).toEqual(true)
+  })
+
+  it('Select display the feedback', () => {
+    const selectWrapper = shallow(
+      <Select id="id" options={options} isInvalid feedback="feedback" />,
+    )
+    const bootstratFeedback = selectWrapper.find(Form.Control.Feedback)
+    expect(bootstratFeedback.props().type).toEqual('invalid')
+    expect(bootstratFeedback.props().children).toEqual('feedback')
   })
 
   it('Select renders as invalid when the isInvalid prop is true', () => {


### PR DESCRIPTION
Fixes #689

**Changes proposed in this pull request:**
- Add feedback for `Select` component.
- I add a div placeholder in `Select`. Because the `Feedback` needs a sibling with a `valid` or `invalid` class name, but the `Typeahead` cannot overwrite the class name.

**Screenshots:**
![image](https://user-images.githubusercontent.com/19623228/106615063-06070800-65a7-11eb-8ab5-85c6f245d0a1.png)
![image](https://user-images.githubusercontent.com/19623228/106615120-14552400-65a7-11eb-83b6-46b667dfe291.png)

