### PR TITLE
refactor: buttonType and ButtonVariant are identical. Using ButtonType

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties } from 'react'
 import BootstrapButton from 'react-bootstrap/Button'
 
-import { ButtonVariant } from '../../interfaces'
 import { Icon } from '../Icon'
 import { IconType } from '../Icon/interfaces'
 import { ButtonType } from './interfaces'
@@ -17,7 +16,7 @@ export interface ButtonProps {
    *  Defines the button variant. By default is primary
    * @default "primary"
    */
-  color?: ButtonVariant
+  color?: ButtonType
 
   /**
    * Determines whether or not the button should be a block button or not. By default false


### PR DESCRIPTION
Button.tsx imports identical ButtonVariant and ButtonType interfaces. Use ButtonType from interface file
alongside component.

**Changes proposed in this pull request:**
- Import ButtonType types from interface file in component folder.
- Keep ButtonVariant around as it is used in other components (for now).
